### PR TITLE
Remove top margin from autocomplete dropdown

### DIFF
--- a/src/resources/idpselect.css
+++ b/src/resources/idpselect.css
@@ -177,6 +177,7 @@ ul.IdPSelectDropDown {
     border: 1px solid black;
     z-index: 6;
     position: absolute;   
+    margin-top: 0px;
 }
 
 ul.IdPSelectDropDown li {


### PR DESCRIPTION
This is what it looks like now. Better!
![screenshot 2016-08-28 at 3 03 28 am](https://cloud.githubusercontent.com/assets/6471953/18032201/0d054a6e-6ccc-11e6-8488-65e6a1b70b12.png)

![tom](https://cloud.githubusercontent.com/assets/6471953/18032212/7031e8a4-6ccc-11e6-981b-4e309d14efb2.gif)

Fixes #8 
