### PR TITLE
Add a link for GPO login information

### DIFF
--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -15,6 +15,9 @@
     <div id="idpSelect"></div>
   </div>
   <div id="footer">
+    <p><a href="http://groups.geni.net/geni/wiki/InCommon/GpoLogin">
+      Looking for the GENI Project Office login?</a></p>
+    <hr>
     <p>Can't find your school or organization above?<br>
     <a href="https://go.ncsa.illinois.edu/geni">Request an account</a>&nbsp;|&nbsp;
     <a href="mailto:help@geni.net">Contact GENI Help</a></p>


### PR DESCRIPTION
The GPO login is going away. Add a "Looking for GPO Login?" link
that takes users to a wiki page explaining what to do.